### PR TITLE
Fixed an error with referencing the Monitor class. Still needs some work regarding spacial cases of gym environments.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@
 /dist/
 /docs/_*
 /tensorforce.egg-info/
+/Tensorforce.egg-info/
 
 /logs/
 /saving-test/

--- a/tensorforce/environments/openai_gym.py
+++ b/tensorforce/environments/openai_gym.py
@@ -47,7 +47,7 @@ class OpenAIGym(Environment):
                 video_callable = False
             else:
                 video_callable = (lambda x: x % monitor_video == 0)
-            self.gym = gym.wrappers.Monitor(self.gym, monitor, force=not monitor_safe, video_callable=video_callable)
+            self.gym = Monitor(self.gym, monitor, force=not monitor_safe, video_callable=video_callable)
 
         self.states_spec = OpenAIGym.specs_from_gym_space(
             space=self.gym.observation_space, ignore_value_bounds=True

--- a/tensorforce/environments/openai_gym.py
+++ b/tensorforce/environments/openai_gym.py
@@ -14,6 +14,7 @@
 # ==============================================================================
 
 import gym
+from gym.wrappers import Monitor
 
 from tensorforce import TensorforceError
 from tensorforce.environments import Environment
@@ -69,7 +70,7 @@ class OpenAIGym(Environment):
         self.gym = None
 
     def reset(self):
-        if isinstance(self.gym, gym.wrappers.Monitor):
+        if isinstance(self.gym, Monitor):
             self.gym.stats_recorder.done = True
         states = self.gym.reset()
         return OpenAIGym.flatten_state(state=states)


### PR DESCRIPTION
Works now with all the standard gym environments. Does not yet work with my custom one, having 
```
self.observation_space = spaces.MultiDiscrete([1,2,3])
```
Getting the following error
```
...
~/tensorforce/tensorforce/util.py in valid_value_spec(value_spec, value_type, accept_underspecified, return_normalized)
    390             if not isinstance(num_values, int):
    391                 raise TensorforceError.type(
--> 392                     name=(value_type + ' spec'), argument='num_values', value=num_values
    393                 )
    394             if accept_underspecified:

TensorforceError: Invalid type for state spec argument num_values: <class 'numpy.uint32'>.
```