### PR TITLE
fix Agent seeding

### DIFF
--- a/tensorforce/agents/agent.py
+++ b/tensorforce/agents/agent.py
@@ -113,7 +113,7 @@ class Agent(object):
     ):
         if seed is not None:
             assert isinstance(seed, int)
-            random.seed(n=seed)
+            random.seed(a=seed)
             np.random.seed(seed=seed)
             tf.random.set_random_seed(seed=seed)
 

--- a/test/test_agents.py
+++ b/test/test_agents.py
@@ -16,12 +16,18 @@
 import unittest
 
 from test.unittest_base import UnittestBase
+from tensorforce.agents import Agent
+from tensorforce.environments import Environment
 
 
 class TestAgents(UnittestBase, unittest.TestCase):
 
     agent = dict()
     require_observe = True
+
+    def test_create_agent_with_seed(self):
+        environment = Environment.create(environment='gym', level='CartPole-v1')
+        Agent.create(agent='ppo', environment=environment, seed=0)
 
     def test_ac(self):
         self.start_tests(name='AC')


### PR DESCRIPTION
fixes typo in Agent.__init__ resulting in an exception when seed is not None.
added unit test to test_agent, which simply instantiates an agent with a non-trivial seed

question: is this the right place for a unit test like this ? is there a better way to test the instantiation with a seed ?