### PR TITLE
Multiprocessing wrapper

### DIFF
--- a/tensorforce/environments/environment_process_wrapper.py
+++ b/tensorforce/environments/environment_process_wrapper.py
@@ -1,0 +1,72 @@
+from tensorforce.environments import Environment
+from tensorforce import TensorforceError, util
+
+from multiprocessing import Process
+from multiprocessing import Pipe
+
+import importlib
+import json
+import os
+from threading import Thread
+
+def worker(environment, conn2):
+    while True:
+        # Receive the environment method's name, and (optional) arguments
+        (name, *args, kwargs) = conn2.recv()
+
+        attr = object.__getattribute__(environment, name)
+        if hasattr(attr, '__call__'):
+            # Get what is returned by the method
+            result = attr(*args, **kwargs)
+        else:
+            # Get the attribute
+            result = attr
+
+        # Send this to the Wrapper
+        conn2.send(result)
+
+class ProcessWrapper(Environment):
+    def __init__(self, environment):
+        super(ProcessWrapper, self).__init__()
+
+        # Instanciate a bidirectional Pipe
+        self.conn1, conn2 = Pipe(duplex=True)
+
+        # Start the worker process, which interacts directly with the environment
+        self.p = Process(target=worker, args=(environment, conn2))
+        self.p.start()
+
+    # To call a custom method of your environment
+    def __getattr__(self, name):
+        def wrapper(*args, **kwargs):
+            return self.send_environment(name, *args, **kwargs)
+        return wrapper
+
+    def send_environment(self, name, *args, **kwargs):
+        """Send a request through the pipe, and wait for the answer message.
+        """
+        to_send = (name, *args, kwargs)
+
+        # Send request
+        self.conn1.send(to_send)
+
+        # Wait for the result
+        result = self.conn1.recv()
+
+        return result
+    
+    def close(self, *args, **kwargs):
+        self.p.join()
+        self.send_environment('close', *args, **kwargs)
+
+    def states(self, *args, **kwargs):
+        return self.send_environment('states', *args, **kwargs)
+
+    def actions(self, *args, **kwargs):
+        return self.send_environment('actions', *args, **kwargs)
+
+    def reset(self, *args, **kwargs):
+        return self.send_environment('reset', *args, **kwargs)
+
+    def execute(self, actions, *args, **kwargs):
+        return self.send_environment('execute', actions, *args, **kwargs)

--- a/tensorforce/environments/environment_process_wrapper.py
+++ b/tensorforce/environments/environment_process_wrapper.py
@@ -1,13 +1,7 @@
 from tensorforce.environments import Environment
-from tensorforce import TensorforceError, util
 
 from multiprocessing import Process
 from multiprocessing import Pipe
-
-import importlib
-import json
-import os
-from threading import Thread
 
 def worker(environment, conn2):
     while True:


### PR DESCRIPTION
This is a wrapper for multicore parallel training using multiprocessing.
To use it with the parallel runner, simply do as you would have before, but wrapping the environments with `ProcessWrapper`

An usage example:
```python3
from tensorforce.execution import ParallelRunner
from tensorforce.environments.environment_process_wrapper import ProcessWrapper

n_env = 8
envs = []

# # Without the wrapper
# for _ in range(n_env):
#     envs.append(Environment.create(...))

# With the wrapper
for _ in range(n_env):
    envs.append(ProcessWrapper(Environment.create(...)))

# Initialize the agent
agent = ...
agent.initialize()

# Initialize the runner
runner = ParallelRunner(agent=agent, environments=envs)

# Start the runner
runner.run(num_episodes=100, sync_episodes=False)
runner.close()
```

On a custom gym environment of mine (the one I used in this paper https://arxiv.org/abs/1910.07788), this wrapper speeds up the execution by a factor of 2.2 as you can see here, with 16 environments.
![comparison_threading_multiprocessing](https://user-images.githubusercontent.com/48254554/68678680-b0d47600-055e-11ea-9195-97c918f79a2a.png)

The reason it's not linearly increasing with the number of environments is:
- I only have 4 cores on my CPU
- the only multi-core computations are the executions in the environments

This means that with simple environments which doesn't require a lot of computation to execute one step, this will not necessarily be faster - actually, `CartPole-v0` is slightly faster to compute without the multiprocessing wrapper because of multiprocessing overhead.