### PR TITLE
dqn config

### DIFF
--- a/benchmarks/configs/dqn.json
+++ b/benchmarks/configs/dqn.json
@@ -1,0 +1,21 @@
+{
+    "agent": "dqn",
+    "network": [
+        {
+            "type": "dense",
+            "size": 100,
+            "activation": "relu"
+        }
+    ],
+    "memory": 100000,
+    "batch_size": 64,
+    "update_frequency": 1,
+    "start_updating": 1000,
+    "learning_rate": 0.001,
+    "discount": 1.0,
+    "preprocessing": null,
+    "exploration": 0.1,
+    "variable_noise": 0.0,
+    "l2_regularization": 0.0,
+    "entropy_regularization": 0.1
+}


### PR DESCRIPTION
I added in the benchmarks/configs folder the dqn configuration following the one used by tf-agents in their tutorial. 

To actually compare the 2 implementations, the Cartpole-v0 env should be used and the training time set to 20000 timesteps. The dqn config now also uses the network definition used (1-layer, 100 neurons) by tf-agents. 

It wasn't quite obvious to me if and how these settings should/could baked into the benchmark. So I'm not sure of this additional config is actually helpful or not.