### PR TITLE
Support for JSON-encoding specific numpy types

### DIFF
--- a/run.py
+++ b/run.py
@@ -1,4 +1,4 @@
-# Copyright 2018 Tensorforce Team. All Rights Reserved.
+# Copyright 2020 Tensorforce Team. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the 'License');
 # you may not use this file except in compliance with the License.
@@ -22,6 +22,7 @@ import matplotlib
 import numpy as np
 
 from tensorforce.agents import Agent
+from tensorforce.core.utils.json_encoder import NumpyJSONEncoder
 from tensorforce.environments import Environment
 from tensorforce.execution import Runner
 
@@ -160,7 +161,7 @@ def main():
                 json.dumps(dict(
                     rewards=rewards, timesteps=timesteps, seconds=seconds,
                     agent_seconds=agent_seconds
-                ))
+                ), cls=NumpyJSONEncoder)
             )
 
         if args.seaborn:

--- a/tensorforce/agents/agent.py
+++ b/tensorforce/agents/agent.py
@@ -1,4 +1,4 @@
-# Copyright 2018 Tensorforce Team. All Rights Reserved.
+# Copyright 2020 Tensorforce Team. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -13,17 +13,18 @@
 # limitations under the License.
 # ==============================================================================
 
-from collections import OrderedDict
 import importlib
 import json
 import os
 import random
 import time
+from collections import OrderedDict
 
 import numpy as np
 
-from tensorforce import util, TensorforceError
 import tensorforce.agents
+from tensorforce import util, TensorforceError
+from tensorforce.core.utils.json_encoder import NumpyJSONEncoder
 
 
 class Agent(object):
@@ -315,7 +316,7 @@ class Agent(object):
         if self.model.saver_directory is not None:
             file = os.path.join(self.model.saver_directory, self.model.saver_filename + '.json')
             with open(file, 'w') as fp:
-                json.dump(obj=self.spec, fp=fp)
+                json.dump(obj=self.spec, fp=fp, cls=NumpyJSONEncoder)
 
         self.reset()
 
@@ -627,7 +628,7 @@ class Agent(object):
             filename = 'agent'
         file = os.path.join(directory, filename + '.json')
         with open(file, 'w') as fp:
-            json.dump(obj=self.spec, fp=fp)
+            json.dump(obj=self.spec, fp=fp, cls=NumpyJSONEncoder)
 
         return result
 

--- a/tensorforce/core/utils/json_encoder.py
+++ b/tensorforce/core/utils/json_encoder.py
@@ -1,0 +1,30 @@
+# Copyright 2020 Tensorforce Team. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+
+from json import JSONEncoder
+
+import numpy as np
+
+
+class NumpyJSONEncoder(JSONEncoder):
+    """
+    Numpy-compatible JSON encoder.
+    """
+
+    def default(self, obj):
+        if isinstance(obj, np.floating):
+            return float(obj)
+
+        return super().default(obj)


### PR DESCRIPTION
Implemented a simple JSONEncoder to serialize numpy floating point
numbers, which doesn't work otherwise. This is necessary for saving
an agent. More cases can be added once they are identified not working.