### PR TITLE
corrected filename truncation for h5-files

### DIFF
--- a/tensorforce/agents/agent.py
+++ b/tensorforce/agents/agent.py
@@ -883,8 +883,11 @@ class Agent(object):
             elif filename.endswith('.npz'):
                 filename = filename[:-4]
                 format = 'numpy'
-            elif filename.endswith('.hdf5') or filename.endswith('.h5'):
+            elif filename.endswith('.hdf5'):
                 filename = filename[:-5]
+                format = 'hdf5'
+            elif filename.endswith('.h5'):
+                filename = filename[:-3]
                 format = 'hdf5'
             else:
                 assert False


### PR DESCRIPTION
The filename truncation should be different, depending if the filename ends with ".hdf5" or ".h5"