### PR TITLE
Save checkpoint instead of write

### DIFF
--- a/tensorforce/agents/agent.py
+++ b/tensorforce/agents/agent.py
@@ -1054,11 +1054,9 @@ class Agent(object):
                     assert format == 'checkpoint'
                 if filename is None or not os.path.isfile(os.path.join(directory, filename + '.index')):
                     path = tf.train.latest_checkpoint(checkpoint_dir=directory)
-                    # TODO: path or filename returned?
-                    if '/' in path:
-                        filename = path[path.rindex('/') + 1:]
-                    else:
-                        filename = path
+                    if not path:
+                        raise TensorforceError.exists_not(name='Checkpoint', value=directory)
+                    filename = os.path.basename(path)
 
             else:
                 if format is None:

--- a/tensorforce/core/models/model.py
+++ b/tensorforce/core/models/model.py
@@ -688,7 +688,13 @@ class Model(Module):
             # always write temporary terminal=2/3 to indicate it is in process... has been removed recently...
             # check everywhere temrinal is checked that this is correct, if 3 is used.
             # Reset should reset estimator!!!
-            return super().save(directory=directory, filename=filename)
+            if self.checkpoint is None:
+                self.checkpoint = tf.train.Checkpoint(**{self.name: self})
+            
+            # We are using the high-level "save" method of the checkpoint to write a "checkpoint" file.
+            # This makes it easily restorable later on.
+            # The base class uses the lower level "write" method, which doesn't provide such niceties.
+            return self.checkpoint.save(file_prefix=os.path.join(directory, filename))
 
         # elif format == 'tensorflow':
         #     if self.summarizer_spec is not None:


### PR DESCRIPTION
Hi,

I switched the checkpoint saving method from "write" to "save", as write doesn't create a "checkpoint" file which allows restoring afterwards (see https://www.tensorflow.org/api_docs/python/tf/train/Checkpoint#write). Was it intentional to use write?

I also added an error message when there's no checkpoint, and simplified the code to extract the filename. Nothing really fancy.

Thanks!
Benjamin