### PR TITLE
Update setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -103,7 +103,7 @@ setup(
     python_requires='>=3.5',
     install_requires=install_requires,
     extras_require=dict(
-        tf=['tensorflow'],
+        tf=['tensorflow>=2.2'],
         tf_gpu=['tensorflow-gpu'],
         tfa=['tensorflow-addons'],
         docs=['m2r', 'recommonmark', 'sphinx', 'sphinx-rtd-theme'],


### PR DESCRIPTION
minimal tensorflow version 2.2

i think its worth validating that again, but it seems (#696) the new branch does **not** work with:
- tf 2.0.1
- tf 2.1.1

![image](https://user-images.githubusercontent.com/2736207/84644163-175bb100-aeff-11ea-91e7-d3facb636a89.png)
