### PR TITLE
Fixed skip_linear if not used with shape parameter in action_values

### DIFF
--- a/tensorforce/core/distributions/categorical.py
+++ b/tensorforce/core/distributions/categorical.py
@@ -90,11 +90,8 @@ class Categorical(Distribution):
                     name=name, argument='input_spec.shape', value=self.input_spec.shape,
                     hint='!= (*action_shape, num_values)'
                 )
-            if self.input_spec.shape[:-1] == self.action_spec.shape[:-1]:
-                size = self.action_spec.shape[-1]
-            elif self.input_spec.shape[:-1] == self.action_spec.shape:
-                size = 1
-            else:
+                
+            elif not (self.input_spec.shape[:-1] == self.action_spec.shape or self.input_spec.shape[:-1] == self.action_spec.shape[:-1]):
                 raise TensorforceError.value(
                     name=name, argument='input_spec.shape', value=self.input_spec.shape,
                     hint='not flattened and incompatible with action shape'

--- a/test/test_policies.py
+++ b/test/test_policies.py
@@ -111,3 +111,14 @@ class TestPolicies(UnittestBase, unittest.TestCase):
                 distributions=dict(type='categorical', skip_linear=True)
             )
         )
+
+    def test_categorical_skip_linear_no_shape(self):
+        self.start_tests(name='categorical skip-linear empty shape')
+        self.unittest(
+            states=dict(type='float', shape=(3,), min_value=1.0, max_value=2.0),
+            actions=dict(type='int', num_values=4),
+            policy=dict(
+                network=[dict(type='dense', size=4)],
+                distributions=dict(type='categorical', skip_linear=True)
+            )
+        )

--- a/test/unittest_environment.py
+++ b/test/unittest_environment.py
@@ -139,7 +139,10 @@ class UnittestEnvironment(Environment):
 
     @classmethod
     def random_mask(cls, action_spec):
-        shape = action_spec['shape'] + (action_spec['num_values'],)
+        if 'shape' in action_spec:
+            shape = action_spec['shape'] + (action_spec['num_values'],)
+        else:
+            shape = (action_spec['num_values'],)
         mask = np.random.random_sample(size=shape)
         min_mask = np.amin(mask, -1, keepdims=True)
         max_mask = np.amax(mask, -1, keepdims=True)


### PR DESCRIPTION
Hi @AlexKuhnle , 

in your commit to https://github.com/tensorforce/tensorforce/issues/783 I noticed there was a problem while using skip_linear in conjunction with an environment with defines the actions without the optional shape parameter. I had a look into it and (if I am not mistaken) there was some unnecessary code which caused the error. I removed it and additionally added a fitting unittest. 