### PR TITLE
Fixed bug communications larger than MAX_BYTES

### DIFF
--- a/tensorforce/environments/socket_environment.py
+++ b/tensorforce/environments/socket_environment.py
@@ -78,7 +78,7 @@ class SocketEnvironment(RemoteEnvironment):
         str_result = b''
         for n in range(num_bytes // cls.MAX_BYTES):
             str_result += connection.recv(cls.MAX_BYTES)
-            if len(str_result) != n * cls.MAX_BYTES:
+            if len(str_result) != (n + 1) * cls.MAX_BYTES:
                 raise TensorforceError.unexpected()
         str_result += connection.recv(num_bytes % cls.MAX_BYTES)
         if len(str_result) != num_bytes:
@@ -115,7 +115,7 @@ class SocketEnvironment(RemoteEnvironment):
         str_function = b''
         for n in range(num_bytes // cls.MAX_BYTES):
             str_function += connection.recv(cls.MAX_BYTES)
-            if len(str_function) != n * cls.MAX_BYTES:
+            if len(str_function) != (n + 1) * cls.MAX_BYTES:
                 raise TensorforceError.unexpected()
         str_function += connection.recv(num_bytes % cls.MAX_BYTES)
         if len(str_function) != num_bytes:


### PR DESCRIPTION
After the first iteration, `str_result` should have length `cls.MAX_BYTES`, however, since `n = 0`, the checks will return an error even if the `recv` operation was successful. With this fix, we check that the string has the correct length