### PR TITLE
🐛: TensorforceError has no attribute 'dtype'. So fixed typo TensorforceError.dtype -> TensorforceError.type (Bagfix)

### DIFF
--- a/tensorforce/core/parameters/constant.py
+++ b/tensorforce/core/parameters/constant.py
@@ -35,13 +35,13 @@ class Constant(Parameter):
     def __init__(self, value, *, name=None, dtype=None, min_value=None, max_value=None):
         if isinstance(value, bool):
             if dtype != 'bool':
-                raise TensorforceError.dtype(name='Constant', argument='value', dtype=type(value))
+                raise TensorforceError.type(name='Constant', argument='value', dtype=type(value))
         elif isinstance(value, int):
             if dtype != 'int':
-                raise TensorforceError.dtype(name='Constant', argument='value', dtype=type(value))
+                raise TensorforceError.type(name='Constant', argument='value', dtype=type(value))
         elif isinstance(value, float):
             if dtype != 'float':
-                raise TensorforceError.dtype(name='Constant', argument='value', dtype=type(value))
+                raise TensorforceError.type(name='Constant', argument='value', dtype=type(value))
         else:
             raise TensorforceError.unexpected()
         if min_value is not None and value < min_value:

--- a/tensorforce/core/parameters/decaying.py
+++ b/tensorforce/core/parameters/decaying.py
@@ -135,12 +135,12 @@ class Decaying(Parameter):
 
         if isinstance(initial_value, int):
             if dtype != 'int':
-                raise TensorforceError.dtype(
+                raise TensorforceError.type(
                     name='Decaying', argument='initial_value', dtype=type(initial_value)
                 )
         elif isinstance(initial_value, float):
             if dtype != 'float':
-                raise TensorforceError.dtype(
+                raise TensorforceError.type(
                     name='Decaying', argument='initial_value', dtype=type(initial_value)
                 )
         else:


### PR DESCRIPTION
Hi developers!

As commented in the issue #879, TensorforceError has no attribute 'dtype', but it has ['type' method](https://github.com/tensorforce/tensorforce/blob/master/tensorforce/exception.py#L128).
So fixed bellow typo by this PR

https://github.com/tensorforce/tensorforce/blob/868d12d7db655c816dc1439dd7826eef06d6ef0e/tensorforce/core/parameters/decaying.py#L136-L145

https://github.com/tensorforce/tensorforce/blob/868d12d7db655c816dc1439dd7826eef06d6ef0e/tensorforce/core/parameters/constant.py#L35-L44

I really appreciate for your time and effort.