### PR TITLE
Setting maximum version of 'gym'

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-gym >= 0.21.0
+gym >= 0.21.0, < 0.23
 h5py >= 3.6.0
 matplotlib >= 3.5.1
 msgpack >= 1.0.3


### PR DESCRIPTION
With higher gym versions, it shows :

`AttributeError: module 'gym.wrappers' has no attribute 'Monitor'`

I attempt to fix it, but it throwed further errors that makes it non working.
In some versions, it's error about `gym.envs.registry.env_specs` that needs to be changed to `gym.envs.registry` in whole `openai_gym.py` file, but there was also errors about `assert spec is not None` and it was done, as API to specs changed. 