### PR TITLE
Use legacy optimizers and fix NotImplementedError when loading an agent

### DIFF
--- a/tensorforce/core/optimizers/tf_optimizer.py
+++ b/tensorforce/core/optimizers/tf_optimizer.py
@@ -22,14 +22,14 @@ from tensorforce.core.optimizers import Optimizer
 
 
 tensorflow_optimizers = dict(
-    adadelta=tf.keras.optimizers.Adadelta,
-    adagrad=tf.keras.optimizers.Adagrad,
-    adam=tf.keras.optimizers.Adam,
-    adamax=tf.keras.optimizers.Adamax,
-    ftrl=tf.keras.optimizers.Ftrl,
-    nadam=tf.keras.optimizers.Nadam,
-    rmsprop=tf.keras.optimizers.RMSprop,
-    sgd=tf.keras.optimizers.SGD
+    adadelta=tf.keras.optimizers.legacy.Adadelta,
+    adagrad=tf.keras.optimizers.legacy.Adagrad,
+    adam=tf.keras.optimizers.legacy.Adam,
+    adamax=tf.keras.optimizers.legacy.Adamax,
+    ftrl=tf.keras.optimizers.legacy.Ftrl,
+    nadam=tf.keras.optimizers.legacy.Nadam,
+    rmsprop=tf.keras.optimizers.legacy.RMSprop,
+    sgd=tf.keras.optimizers.legacy.SGD
 )
 
 

--- a/tensorforce/core/utils/dicts.py
+++ b/tensorforce/core/utils/dicts.py
@@ -32,10 +32,7 @@ class TrackableNestedDict(NestedDict, AutoTrackable):
         )
 
     def __setattr__(self, name, value):
-        if name.startswith('_self_'):
-            super(NestedDict, self).__setattr__(name, value)
-        else:
-            super().__setattr__(name, value)
+        super(NestedDict, self).__setattr__(name, value)
 
     def __setitem__(self, key, value):
         if key is None:


### PR DESCRIPTION
- Use legacy optimizers for compatibility with TF 2.11.1.
- Fix `NotImplementedError` when loading an agent.